### PR TITLE
chore: remove flaky test

### DIFF
--- a/src/test/java/io/ionic/libs/ionfilesystemlib/helper/IONFILELocalFilesHelperTest.kt
+++ b/src/test/java/io/ionic/libs/ionfilesystemlib/helper/IONFILELocalFilesHelperTest.kt
@@ -610,30 +610,6 @@ class IONFILELocalFilesHelperTest : IONFILEBaseJUnitTest() {
         }
 
     @Test
-    fun `given file is updated after creation, when getting file metadata, the lastModifiedTimestamp is more recent than the created`() =
-        runTest {
-            val path = fileInRootDir.absolutePath
-            sut.createFile(path, IONFILECreateOptions(recursive = false))
-            testScheduler.advanceTimeBy(60_000L)
-            sut.saveFile(
-                path,
-                IONFILESaveOptions(
-                    data = "1",
-                    encoding = IONFILEEncoding.DefaultCharset,
-                    mode = IONFILESaveMode.WRITE,
-                    createFileRecursive = false
-                )
-            )
-
-            val result = sut.getFileMetadata(path)
-
-            assertTrue(result.isSuccess)
-            result.getOrNull()!!.let {
-                assertTrue(it.lastModifiedTimestamp > it.createdTimestamp!!)
-            }
-        }
-
-    @Test
     fun `given Android version below 26, when getting file metadata, createdTimestamp is zero`() =
         runTest {
             val path = fileInRootDir.absolutePath


### PR DESCRIPTION
This PR removes a flaky test.

The particular test was passing in macOS, but [failed sometimes in ubuntu](https://github.com/ionic-team/ion-android-filesystem/actions/runs/13968140923/job/39103211663), which could cause issues with publishing the plugin.

I kind of had some troubles getting the test to work on mac on my machine, and since the test was basically relying on how Java's implementation of files works on each OS, it's not a very relevant test to have.