### PR TITLE
fix: Add missing trailing slash in directories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
     <artifactId>ionfilesystem-android</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
 </project>

--- a/src/test/java/io/ionic/libs/ionfilesystemlib/helper/IONFILEControllerTests.kt
+++ b/src/test/java/io/ionic/libs/ionfilesystemlib/helper/IONFILEControllerTests.kt
@@ -22,7 +22,6 @@ import io.ionic.libs.ionfilesystemlib.model.IONFILEReadOptions
 import io.ionic.libs.ionfilesystemlib.model.IONFILESaveMode
 import io.ionic.libs.ionfilesystemlib.model.IONFILESaveOptions
 import io.ionic.libs.ionfilesystemlib.model.IONFILEUri
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -43,7 +42,6 @@ import kotlin.math.ceil
  * These tests are not 100% exhaustive of the entire library.
  * That is because most of the logic is covered in IONFILE(...)HelperTest classes
  */
-@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 class IONFILEControllerTests {
 
@@ -94,7 +92,7 @@ class IONFILEControllerTests {
 
             assertTrue(result.isSuccess)
             assertEquals(
-                Uri.parse("file://${context.getExternalFilesDir(null)!!.absolutePath}/subDir1/subDir2/directory"),
+                Uri.parse("file://${context.getExternalFilesDir(null)!!.absolutePath}/subDir1/subDir2/directory/"),
                 result.getOrNull()
             )
         }
@@ -334,7 +332,7 @@ class IONFILEControllerTests {
 
         assertTrue(result.isSuccess)
         assertEquals(
-            Uri.parse("file://${context.filesDir.absolutePath}/f"),
+            Uri.parse("file://${context.filesDir.absolutePath}/f/"),
             result.getOrNull()
         )
     }
@@ -402,7 +400,7 @@ class IONFILEControllerTests {
 
         assertTrue(result.isSuccess)
         assertEquals(
-            Uri.parse("file://${context.filesDir.absolutePath}/f"),
+            Uri.parse("file://${context.filesDir.absolutePath}/f/"),
             result.getOrNull()
         )
     }

--- a/src/test/java/io/ionic/libs/ionfilesystemlib/helper/IONFILELocalFilesHelperTest.kt
+++ b/src/test/java/io/ionic/libs/ionfilesystemlib/helper/IONFILELocalFilesHelperTest.kt
@@ -180,6 +180,30 @@ class IONFILELocalFilesHelperTest : IONFILEBaseJUnitTest() {
         }
 
     @Test
+    fun `given non-empty file exists, when reading file with extra file separator, success is returned with contents`() =
+        runTest {
+            val file = File(testRootDirectory, "subdir/extra_separator.txt")
+            val path = file.absolutePath
+            val pathExtraSeparator = path.replace("subdir/", "subdir//")
+            sut.saveFile(
+                path,
+                IONFILESaveOptions(
+                    LOREM_IPSUM_2800_CHARS,
+                    IONFILEEncoding.DefaultCharset,
+                    IONFILESaveMode.WRITE,
+                    createFileRecursive = true
+                )
+            )
+
+            val result = sut.readFile(
+                pathExtraSeparator, IONFILEReadOptions(encoding = IONFILEEncoding.DefaultCharset)
+            )
+
+            assertTrue(result.isSuccess)
+            assertEquals(LOREM_IPSUM_2800_CHARS, result.getOrNull())
+        }
+
+    @Test
     fun `given non-empty file saved as base64, when reading file as utf-8, success is returned with utf-8 string`() =
         runTest {
             val file = fileInRootDir

--- a/src/test/java/io/ionic/libs/ionfilesystemlib/helper/IONFILELocalFilesHelperTest.kt
+++ b/src/test/java/io/ionic/libs/ionfilesystemlib/helper/IONFILELocalFilesHelperTest.kt
@@ -14,7 +14,6 @@ import io.ionic.libs.ionfilesystemlib.model.IONFILEReadOptions
 import io.ionic.libs.ionfilesystemlib.model.IONFILESaveMode
 import io.ionic.libs.ionfilesystemlib.model.IONFILESaveOptions
 import io.mockk.every
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -23,7 +22,6 @@ import org.junit.Test
 import java.io.File
 import java.util.Base64
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class IONFILELocalFilesHelperTest : IONFILEBaseJUnitTest() {
 
     private lateinit var sut: IONFILELocalFilesHelper

--- a/src/test/java/io/ionic/libs/ionfilesystemlib/helper/IONFILEUriHelperTest.kt
+++ b/src/test/java/io/ionic/libs/ionfilesystemlib/helper/IONFILEUriHelperTest.kt
@@ -111,8 +111,8 @@ class IONFILEUriHelperTest {
 
             assertEquals(
                 IONFILEUri.Resolved.Local(
-                    "${context.filesDir}/$path",
-                    Uri.parse("file://${context.filesDir}/$path"),
+                    "${context.filesDir}/$path/",
+                    Uri.parse("file://${context.filesDir}/$path/"),
                     LocalUriType.DIRECTORY,
                     inExternalStorage = false
                 ),
@@ -131,8 +131,8 @@ class IONFILEUriHelperTest {
 
             assertEquals(
                 IONFILEUri.Resolved.Local(
-                    "${context.externalCacheDir}/$path",
-                    fileUriWithEncodings("file://${context.externalCacheDir}/$path"),
+                    "${context.externalCacheDir}/$path/",
+                    fileUriWithEncodings("file://${context.externalCacheDir}/$path/"),
                     LocalUriType.UNKNOWN,
                     inExternalStorage = false
                 ),
@@ -150,8 +150,8 @@ class IONFILEUriHelperTest {
 
             assertEquals(
                 IONFILEUri.Resolved.Local(
-                    "${context.getExternalFilesDir(null)}/$path",
-                    fileUriWithEncodings("file://${context.getExternalFilesDir(null)}/$path"),
+                    "${context.getExternalFilesDir(null)}/$path/",
+                    fileUriWithEncodings("file://${context.getExternalFilesDir(null)}/$path/"),
                     LocalUriType.UNKNOWN,
                     inExternalStorage = false
                 ),
@@ -162,7 +162,8 @@ class IONFILEUriHelperTest {
     @Test
     fun `given non-existent directory path in external storage, when resolving the uri, a Resolves#Local is returned`() =
         runTest {
-            val path = "this is a directory/with multiple/parent/folders"
+            // trailing slash present, to make sure it does not get added again
+            val path = "this is a directory/with multiple/parent/folders/"
             val unresolvedUri = IONFILEUri.Unresolved(IONFILEFolderType.EXTERNAL_STORAGE, path)
 
             val result = sut.resolveUri(unresolvedUri)

--- a/src/test/java/io/ionic/libs/ionfilesystemlib/helper/IONFILEUriHelperTest.kt
+++ b/src/test/java/io/ionic/libs/ionfilesystemlib/helper/IONFILEUriHelperTest.kt
@@ -101,18 +101,19 @@ class IONFILEUriHelperTest {
         }
 
     @Test
-    fun `given there is an internal files directory, when resolving the uri, a Resolves#Local is returned`() =
+    fun `given there is an internal files directory with extra file separators, when resolving the uri, a Resolves#Local is returned`() =
         runTest {
-            val path = "path/to/directory"
+            val path = "path//to//directory"
             File(context.filesDir, path).mkdirs()
             val unresolvedUri = IONFILEUri.Unresolved(IONFILEFolderType.INTERNAL_FILES, path)
+            val expectedPath = path.replace("//", "/")
 
             val result = sut.resolveUri(unresolvedUri)
 
             assertEquals(
                 IONFILEUri.Resolved.Local(
-                    "${context.filesDir}/$path/",
-                    Uri.parse("file://${context.filesDir}/$path/"),
+                    "${context.filesDir}/$expectedPath/",
+                    Uri.parse("file://${context.filesDir}/$expectedPath/"),
                     LocalUriType.DIRECTORY,
                     inExternalStorage = false
                 ),


### PR DESCRIPTION
## Description

Proper fix on Android, that adds a missing trailing slash '/' in directories, to [drop this PR](https://github.com/ionic-team/cordova-outsystems-file/pull/10).

Note that with this change, it increases the odds of users adding an unnecessary extra trailing slash. On Android, with Java File, this causes no issues, as covered by the unit tests that were updated in this PR.

## Context

The goal here is to have the same behavior as the existing Cordova file plugin, while also not breaking the existing Capacitor filesystem plugin.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests

Update tests to make sure trailing slash is added, while also making sure duplicated slashes don't cause issues.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
