### PR TITLE
RNMT-9 fix: use Long for offset to support files larger than 2.14GB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0]
+## [1.2.0]
 
 ### 2026-03-10
 
 - Fix: Change `offset` parameter type from `Int` to `Long` in `IONFILEReadOptions` and `IONFILEReadInChunksOptions` to support files larger than 2.14GB.
+
+## [1.1.0]
 
 ### 2025-12-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0]
 
+### 2026-03-10
+
+- Fix: Change `offset` parameter type from `Int` to `Long` in `IONFILEReadOptions` and `IONFILEReadInChunksOptions` to support files larger than 2.14GB.
+
 ### 2025-12-31
 
 - Feature: Add optional `length` and `offset` parameters to `readFile` and `readFileInChunks`.

--- a/src/main/kotlin/io/ionic/libs/ionfilesystemlib/helper/common/IONFILECommon.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfilesystemlib/helper/common/IONFILECommon.kt
@@ -138,7 +138,7 @@ internal inline fun prepareForCopyOrRename(
  * @param offset the number of bytes to skip before reading; must be >= 0
  * @param length the maximum number of bytes to read; must be > 0
  */
-internal fun validateOffsetAndLength(offset: Int, length: Int) {
+internal fun validateOffsetAndLength(offset: Long, length: Int) {
     require(offset >= 0) { "offset must be >= 0, but was $offset" }
     require(length > 0) { "length must be > 0, but was $length" }
 }

--- a/src/main/kotlin/io/ionic/libs/ionfilesystemlib/helper/common/IONFILEInputStreamExtensions.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfilesystemlib/helper/common/IONFILEInputStreamExtensions.kt
@@ -140,8 +140,9 @@ private fun processReadChunk(
 private fun InputStream.calculateChunkSizeToUse(
     options: IONFILEReadInChunksOptions,
     bufferSize: Int,
-): Int = minOf(options.chunkSize, minOf(available() - options.offset, options.length))
-    .coerceAtLeast(bufferSize)
+): Int = minOf(options.chunkSize.toLong(), minOf(available().toLong() - options.offset, options.length.toLong()))
+    .coerceAtLeast(bufferSize.toLong())
+    .toInt()
     .let {
         options.encoding.convertChunkSize(it)
     }
@@ -155,15 +156,15 @@ private fun IONFILEEncoding.convertChunkSize(chunkSize: Int) = if (this == IONFI
 }
 
 @SuppressLint("NewApi")
-private fun InputStream.applyOffset(offset: Int) {
+private fun InputStream.applyOffset(offset: Long) {
     if (offset <= 0) return
 
     if (IONFILEBuildConfig.getAndroidSdkVersionCode() >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-        this.skipNBytes(offset.toLong())
+        this.skipNBytes(offset)
         return
     }
 
-    var remaining = offset.toLong()
+    var remaining = offset
     while (remaining > 0) {
         val skipped = this.skip(remaining)
         if (skipped > 0) {

--- a/src/main/kotlin/io/ionic/libs/ionfilesystemlib/model/IONFILEReadInChunksOptions.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfilesystemlib/model/IONFILEReadInChunksOptions.kt
@@ -23,6 +23,6 @@ package io.ionic.libs.ionfilesystemlib.model
 data class IONFILEReadInChunksOptions(
     val encoding: IONFILEEncoding,
     val chunkSize: Int,
-    val offset: Int = 0,
+    val offset: Long = 0L,
     val length: Int = IONFILEConstants.LENGTH_READ_TIL_EOF
 )

--- a/src/main/kotlin/io/ionic/libs/ionfilesystemlib/model/IONFILEReadOptions.kt
+++ b/src/main/kotlin/io/ionic/libs/ionfilesystemlib/model/IONFILEReadOptions.kt
@@ -12,6 +12,6 @@ package io.ionic.libs.ionfilesystemlib.model
  */
 data class IONFILEReadOptions(
     val encoding: IONFILEEncoding,
-    val offset: Int = 0,
+    val offset: Long = 0L,
     val length: Int = IONFILEConstants.LENGTH_READ_TIL_EOF
 )

--- a/src/test/java/io/ionic/libs/ionfilesystemlib/helper/IONFILELocalFilesHelperTest.kt
+++ b/src/test/java/io/ionic/libs/ionfilesystemlib/helper/IONFILELocalFilesHelperTest.kt
@@ -693,7 +693,7 @@ class IONFILELocalFilesHelperTest : IONFILEBaseJUnitTest() {
             fullPath = path,
             options = IONFILEReadOptions(
                 encoding = IONFILEEncoding.WithCharset(Charsets.UTF_8),
-                offset = content.length
+                offset = content.length.toLong()
             )
         )
 
@@ -719,7 +719,7 @@ class IONFILELocalFilesHelperTest : IONFILEBaseJUnitTest() {
             fullPath = path,
             options = IONFILEReadInChunksOptions(
                 encoding = IONFILEEncoding.WithCharset(Charsets.UTF_8),
-                offset = content.length + 100,
+                offset = (content.length + 100).toLong(),
                 chunkSize = 10
             )
         ).test {

--- a/src/test/java/io/ionic/libs/ionfilesystemlib/helper/IONFILELocalFilesHelperTest.kt
+++ b/src/test/java/io/ionic/libs/ionfilesystemlib/helper/IONFILELocalFilesHelperTest.kt
@@ -20,6 +20,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
+import java.io.RandomAccessFile
 import java.util.Base64
 
 class IONFILELocalFilesHelperTest : IONFILEBaseJUnitTest() {
@@ -727,6 +728,36 @@ class IONFILELocalFilesHelperTest : IONFILEBaseJUnitTest() {
             awaitComplete()
         }
     }
+    @Test
+    fun `given file larger than 2GB, when readFileInChunks is called with offset beyond Int MAX_VALUE, the correct content is returned`() =
+        runTest {
+            val path = fileInRootDir.absolutePath
+            val contentAfterBoundary = "content_after_2gb_boundary"
+            // offset is one byte past Int.MAX_VALUE (2,147,483,648 bytes)
+            val offset = Int.MAX_VALUE.toLong() + 1
+            // create a sparse file by seeking past the 2GB boundary and writing content there;
+            // the OS will not allocate actual disk space for the empty region
+            RandomAccessFile(path, "rw").use { raf ->
+                raf.seek(offset)
+                raf.writeBytes(contentAfterBoundary)
+            }
+
+            var result = ""
+            sut.readFileInChunks(
+                fullPath = path,
+                options = IONFILEReadInChunksOptions(
+                    encoding = IONFILEEncoding.WithCharset(Charsets.UTF_8),
+                    offset = offset,
+                    chunkSize = Int.MAX_VALUE
+                )
+            ).test {
+                result += awaitItem()
+                awaitComplete()
+            }
+
+            assertEquals(contentAfterBoundary, result)
+        }
+
     // endregion read with offset/length tests
 
     // region fileMetadata tests


### PR DESCRIPTION
## Description
Change `offset` parameter type from `Int` to `Long` in `IONFILEReadOptions` and `IONFILEReadInChunksOptions` to fix file corruption when reading files larger than 2.14GB using chunking.

## Context
When reading files larger than ~2.14GB (`Int.MAX_VALUE` bytes), the `Int` offset would overflow, causing incorrect seek positions and corrupt reads. Changing `offset` to `Long` allows addressing positions beyond the 2.14GB boundary.

## Type of changes
- [x] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android

## Tests
Added a test in `IONFILELocalFilesHelperTest` that creates a sparse file larger than 2GB (no actual disk allocation), writes known content at an offset beyond `Int.MAX_VALUE`, and verifies that `readFileInChunks` returns the correct content when called with that offset.

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
  - [ ] Documentation has been updated accordingly